### PR TITLE
appdata: Remove none OARS tags

### DIFF
--- a/data/io.github.idevecore.CurrencyConverter.appdata.xml.in.in
+++ b/data/io.github.idevecore.CurrencyConverter.appdata.xml.in.in
@@ -59,29 +59,6 @@
       <image>https://raw.githubusercontent.com/ideveCore/currency-converter/developer/data/screenshots/04.png</image>
     </screenshot>
   </screenshots>
-  <content_rating type="oars-1.1">
-    <content_attribute id="violence-cartoon">none</content_attribute>
-    <content_attribute id="violence-fantasy">none</content_attribute>
-    <content_attribute id="violence-realistic">none</content_attribute>
-    <content_attribute id="violence-bloodshed">none</content_attribute>
-    <content_attribute id="violence-sexual">none</content_attribute>
-    <content_attribute id="violence-desecration">none</content_attribute>
-    <content_attribute id="violence-slavery">none</content_attribute>
-    <content_attribute id="violence-worship">none</content_attribute>
-    <content_attribute id="drugs-alcohol">none</content_attribute>
-    <content_attribute id="drugs-narcotics">none</content_attribute>
-    <content_attribute id="drugs-tobacco">none</content_attribute>
-    <content_attribute id="sex-nudity">none</content_attribute>
-    <content_attribute id="language-profanity">none</content_attribute>
-    <content_attribute id="language-humor">none</content_attribute>
-    <content_attribute id="language-discrimination">none</content_attribute>
-    <content_attribute id="social-chat">none</content_attribute>
-    <content_attribute id="social-info">none</content_attribute>
-    <content_attribute id="social-audio">none</content_attribute>
-    <content_attribute id="social-location">none</content_attribute>
-    <content_attribute id="social-contacts">none</content_attribute>
-    <content_attribute id="money-purchasing">none</content_attribute>
-    <content_attribute id="money-gambling">none</content_attribute>
-  </content_rating>
+  <content_rating type="oars-1.1"/>
   <developer_name translatable="no">Ideve Core</developer_name>
 </component>


### PR DESCRIPTION
"The old generator also included all the none-value entries—it no longer does this, you can safely remove them.

If it only consists of none values, it’s safe to shorten it to just: `<content_rating type="oars-1.1" />`"

More information: https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#oars-information